### PR TITLE
Login now starts on username line edit

### DIFF
--- a/src/windows/login.cpp
+++ b/src/windows/login.cpp
@@ -280,6 +280,7 @@ void Login::resetUi() const
     m_ui->label_confirmPassword->setStyleSheet(txtStyle);
     m_ui->label_loginMsg->setText("");
     m_ui->label_regMsg->setText("");
+    m_ui->lineEdit_username->setFocus();
 }
 
 void Login::clearFields() const

--- a/src/windows/login.ui
+++ b/src/windows/login.ui
@@ -14,7 +14,7 @@
    <string notr="true">Login</string>
   </property>
   <property name="windowIcon">
-   <iconset>
+   <iconset resource="../../res.qrc">
     <normaloff>:/res/fff128.png</normaloff>:/res/fff128.png</iconset>
   </property>
   <property name="styleSheet">
@@ -33,7 +33,7 @@
     <string/>
    </property>
    <property name="pixmap">
-    <pixmap>:/res/fff128.png</pixmap>
+    <pixmap resource="../../res.qrc">:/res/fff128.png</pixmap>
    </property>
   </widget>
   <widget class="QStackedWidget" name="stackedWidget">
@@ -46,7 +46,7 @@
     </rect>
    </property>
    <property name="currentIndex">
-    <number>1</number>
+    <number>0</number>
    </property>
    <widget class="QWidget" name="page_login">
     <widget class="QWidget" name="layoutWidget">
@@ -289,6 +289,20 @@
    </widget>
   </widget>
  </widget>
- <resources/>
+ <tabstops>
+  <tabstop>lineEdit_username</tabstop>
+  <tabstop>lineEdit_password</tabstop>
+  <tabstop>pushButton_login</tabstop>
+  <tabstop>pushButton_register</tabstop>
+  <tabstop>checkBox_showPW</tabstop>
+  <tabstop>lineEdit_usernameReg</tabstop>
+  <tabstop>lineEdit_passwordReg</tabstop>
+  <tabstop>lineEdit_confirmPassword</tabstop>
+  <tabstop>pushButton_confirmReg</tabstop>
+  <tabstop>pushButton_cancelReg</tabstop>
+ </tabstops>
+ <resources>
+  <include location="../../res.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
### Key features
* When prompting a login, the initial focus will be set to the username line edit
* A quick sample input would look like `myname` -> `[tab]` -> `mypassword` -> `[enter]`

### Future Improvements
* none

### Notes
none
