### PR TITLE
NavBar cleanup

### DIFF
--- a/src/widgets/navbar.cpp
+++ b/src/widgets/navbar.cpp
@@ -12,6 +12,9 @@ NavBar::NavBar(QWidget* parent, int minWidth, int maxWidth)
     //Initial size
     resize(m_minWidth, parent->height());
 
+    //Sets the parent's size
+    parent->resize(m_minWidth, parent->height());
+
     connect(this, &QListWidget::currentRowChanged, this, &NavBar::currentItemChanged);
 }
 
@@ -31,6 +34,7 @@ void NavBar::setMaxWidth(int width)
     m_maxWidth = width;
 }
 
+/* List modifiers */
 void NavBar::addItem(QString icon, QString label)
 {
     const QSize itemSize(70, 80);
@@ -51,8 +55,15 @@ void NavBar::addItem(QString icon, QString label)
 /* Events */
 void NavBar::leaveEvent(QEvent*)
 {
-    /* Shrinking animation */
-    QPropertyAnimation* animation = new QPropertyAnimation(this, "size");
+    /* Shrinking animation for parent widget */
+    QPropertyAnimation* animation = new QPropertyAnimation(parentWidget(), "size");
+    animation->setDuration(75);
+    animation->setStartValue(size());
+    animation->setEndValue(QSize(m_minWidth, height()));
+    animation->start(QAbstractAnimation::DeleteWhenStopped);
+
+    /* Shrinking animation for list widget */
+    animation = new QPropertyAnimation(this, "size");
     animation->setDuration(75);
     animation->setStartValue(size());
     animation->setEndValue(QSize(m_minWidth, height()));
@@ -64,8 +75,15 @@ void NavBar::leaveEvent(QEvent*)
 
 void NavBar::enterEvent(QEvent*)
 {
-    /* Expanding animation */
-    QPropertyAnimation* animation = new QPropertyAnimation(this, "size");
+    /* Expanding animation for parent widget */
+    QPropertyAnimation* animation = new QPropertyAnimation(parentWidget(), "size");
+    animation->setDuration(75);
+    animation->setStartValue(size());
+    animation->setEndValue(QSize(m_maxWidth, height()));
+    animation->start(QAbstractAnimation::DeleteWhenStopped);
+
+    /* Expanding animation for list widget */
+    animation = new QPropertyAnimation(this, "size");
     animation->setDuration(75);
     animation->setStartValue(size());
     animation->setEndValue(QSize(m_maxWidth, height()));

--- a/src/widgets/navbar.cpp
+++ b/src/widgets/navbar.cpp
@@ -7,7 +7,8 @@ NavBar::NavBar(QWidget* parent, int minWidth, int maxWidth)
     : QListWidget(parent), m_minWidth(minWidth), m_maxWidth(maxWidth)
 {
     parent->raise();
-    setStyleSheet("QListWidget { background-color: #303030; }");
+    setStyleSheet("QListWidget { background-color: #303030; }"
+                  "QListWidget::item:hover { background-color: white; }");
 
     //Initial size
     resize(m_minWidth, parent->height());

--- a/src/widgets/navbar.cpp
+++ b/src/widgets/navbar.cpp
@@ -15,8 +15,6 @@ NavBar::NavBar(QWidget* parent, int minWidth, int maxWidth)
 
     //Sets the parent's size
     parent->resize(m_minWidth, parent->height());
-
-    connect(this, &QListWidget::currentRowChanged, this, &NavBar::currentItemChanged);
 }
 
 /* Setters */

--- a/src/widgets/navbar.hpp
+++ b/src/widgets/navbar.hpp
@@ -14,6 +14,7 @@ public:
     void setMinWidth(int);
     void setMaxWidth(int);
 
+    /* List modifiers */
     void addItem(QString icon, QString label);
 
 signals:

--- a/src/widgets/navbar.hpp
+++ b/src/widgets/navbar.hpp
@@ -20,7 +20,6 @@ public:
 signals:
     void expand();
     void shrink();
-    void currentItemChanged(int);
 
 private:
     /* Events */

--- a/src/widgets/navitem.cpp
+++ b/src/widgets/navitem.cpp
@@ -24,7 +24,7 @@ NavItem::NavItem(QListWidget* parent, QString icon, QString label)
     m_ui->navIcon->setFont(font);
     m_ui->navIcon->setText(icon);
 
-    setStyleSheet("* { background-color: none; color: white}");
+    setStyleSheet("* { color: white; }");
 }
 
 /* Destructor */
@@ -47,10 +47,10 @@ void NavItem::shrink() const
 /* Events */
 void NavItem::enterEvent(QEvent*)
 {
-    setStyleSheet("* { background-color: white; color: black }");
+    setStyleSheet("* { color: black; }");
 }
 
 void NavItem::leaveEvent(QEvent*)
 {
-    setStyleSheet("* { background-color: none; color: white }");
+    setStyleSheet("* { color: white; }");
 }

--- a/src/windows/mainwindow.cpp
+++ b/src/windows/mainwindow.cpp
@@ -26,7 +26,7 @@ MainWindow::MainWindow()
 
     /* Initialize navigation bar and items */
     m_navbar = new NavBar(m_ui->NavBarWidget, 90, 220);
-    connect(m_navbar, &NavBar::currentItemChanged, this, &MainWindow::changeView);
+    connect(m_navbar, &NavBar::currentRowChanged, this, &MainWindow::changeView);
     m_navbar->addItem("\uf0c9", "Dashboard");
     m_navbar->addItem("\uf5a0", "Plan\na Trip");
     m_navbar->addItem("\uf0ca", "View\nRestaurants");

--- a/src/windows/mainwindow.ui
+++ b/src/windows/mainwindow.ui
@@ -132,7 +132,7 @@
      <rect>
       <x>0</x>
       <y>0</y>
-      <width>220</width>
+      <width>90</width>
       <height>600</height>
      </rect>
     </property>


### PR DESCRIPTION
### Key features
* NavBar now resizes its parent widget accordingly. This prevents the parent widget from overlapping other widgets even when not expanded.
* NavItem only deals with coloring the text when its being hovered. NavBar is now responsible for the white background when an item is hovered.
* Removed redundant signal `NavBar::currentItemChanged(int)`, all instances has been replaced with `NavBar::currentRowChanged(int)` (this signal is inherited from `QListWidget`)

### Future Improvements
* none

### Notes
none
