### PR TITLE
Menu item listing

### DIFF
--- a/FastFoodFinder.pro
+++ b/FastFoodFinder.pro
@@ -41,8 +41,7 @@ HEADERS += \
     src/datastore/Trip.hpp \
     src/datastore/TripDataStore.hpp \
     src/datastore/User.hpp \
-    src/datastore/UserDataStore.hpp \
-    src/datastore/MenuItem.hpp \
+    src/datastore/UserDataStore.hpp
 
 
 SOURCES += \
@@ -61,8 +60,7 @@ SOURCES += \
     src/datastore/Trip.cpp \
     src/datastore/TripDataStore.cpp \
     src/datastore/User.cpp \
-    src/datastore/UserDataStore.cpp \
-    src/datastore/MenuItem.cpp \
+    src/datastore/UserDataStore.cpp
 
 FORMS += \
     src/windows/login.ui \

--- a/FastFoodFinder.pro
+++ b/FastFoodFinder.pro
@@ -32,6 +32,8 @@ HEADERS += \
     src/widgets/navbar.hpp \
     src/widgets/navitem.hpp \
     src/widgets/restaurantlist.hpp \
+    src/widgets/menulist.hpp \
+    src/widgets/menulistitem.hpp \
     src/datastore/MyDblLinkList.hpp \
     src/datastore/Restaurant.hpp \
     src/datastore/MenuItem.hpp \
@@ -51,6 +53,8 @@ SOURCES += \
     src/widgets/navbar.cpp \
     src/widgets/navitem.cpp \
     src/widgets/restaurantlist.cpp \
+    src/widgets/menulist.cpp \
+    src/widgets/menulistitem.cpp \
     src/datastore/Restaurant.cpp \
     src/datastore/MenuItem.cpp \
     src/datastore/RestaurantDataStore.cpp \
@@ -63,7 +67,8 @@ SOURCES += \
 FORMS += \
     src/windows/login.ui \
     src/windows/mainwindow.ui \
-    src/widgets/navitem.ui
+    src/widgets/navitem.ui \
+    src/widgets/menulistitem.ui
 
 RESOURCES += \
     res.qrc

--- a/src/widgets/menulist.cpp
+++ b/src/widgets/menulist.cpp
@@ -1,0 +1,119 @@
+#include "menulist.hpp"
+
+/* Constructor */
+MenuList::MenuList(QWidget* parent)
+    : QListWidget(parent)
+{
+    /* List widget settings */
+    QListWidget::setStyleSheet("QListWidget { background-color: #303030; color: white; }");
+    QListWidget::resize(parent->size());
+    QListWidget::setVerticalScrollMode(QAbstractItemView::ScrollPerPixel);
+    QListWidget::setUniformItemSizes(true);
+
+    /* Settings for wrapping */
+    QListWidget::setWrapping(false);
+    QListWidget::setFlow(QListView::TopToBottom);
+
+    //Emits a signal when a menu item is selected with information about the menu item
+    connect(this, &QListWidget::currentRowChanged, this, &MenuList::currentMenuItemHandler);
+}
+
+/* Getters */
+IDQtys MenuList::getIDQty() const
+{
+    return m_IDQtys;
+}
+
+IDs MenuList::getSelected() const
+{
+    //Get the QListWidgetItem at the specified row
+    QListWidgetItem* item = QListWidget::item(QListWidget::currentRow());
+
+    //Attempt to cast the linked widget into a MenuListItem
+    MenuListItem* menuItem = dynamic_cast<MenuListItem*>(QListWidget::itemWidget(item));
+
+    //If successful, return the menu item's IDs
+    if(menuItem != nullptr)
+        return menuItem->getIDs();
+    else
+        return IDs(-1, -1);
+}
+
+/* List modifiers */
+void MenuList::addItem(RestaurantID restID, const MenuItem& menuItem)
+{
+    if(menuItem.IsDeleted())
+        return;
+
+    QListWidgetItem* listItem = new QListWidgetItem(this);
+    listItem->setSizeHint(MenuListItem::getItemSizeHint());
+
+    MenuListItem* widget = new MenuListItem(this, restID, menuItem);
+    QListWidget::setItemWidget(listItem, widget);
+
+    //Allows all MenuItem's to toggle its quantity widgets through the emitter
+    connect(this, &MenuList::showQtyEmitter, widget, &MenuListItem::showQty);
+
+    //Handles the quantity change of a menu item
+    connect(widget, &MenuListItem::quantityChanged, this, &MenuList::quantityChangedHandler);
+
+    //Resets each spinbox of each MenuItem when emitted
+    connect(this, &MenuList::resetQtyEmitter, widget, &MenuListItem::resetQty);
+}
+
+void MenuList::addAllItems(const Restaurant& restaurant)
+{
+    QListWidget::clear();
+
+    for(MenuItem menuItem : restaurant.GetMenu())
+        addItem(restaurant.GetNumber(), menuItem);
+}
+
+void MenuList::removeItem(IDs id)
+{
+    for(int i = 0; i < QListWidget::count(); i++)
+    {
+        QListWidgetItem* listItem = QListWidget::item(i);
+        MenuListItem* widget = dynamic_cast<MenuListItem*>(QListWidget::itemWidget(listItem));
+
+        if(widget != nullptr && id == widget->getIDs())
+        {
+            QListWidget::removeItemWidget(listItem);
+            return;
+        }
+    }
+}
+
+/* Quantity */
+void MenuList::showQty(bool v) const
+{
+    emit showQtyEmitter(v);
+}
+
+void MenuList::resetQty()
+{
+    m_IDQtys.clear();
+    emit resetQtyEmitter();
+}
+
+/* Private slots */
+void MenuList::currentMenuItemHandler(int row) const
+{
+    //Get the QListWidgetItem at the specified row
+    QListWidgetItem* item = QListWidget::item(row);
+
+    //Attempt to cast the linked widget into a MenuListItem
+    MenuListItem* menuItem = dynamic_cast<MenuListItem*>(QListWidget::itemWidget(item));
+
+    //If successful, emit a signal
+    if(menuItem != nullptr)
+        emit currentMenuItemChanged(menuItem->getIDs());
+}
+
+void MenuList::quantityChangedHandler(IDs id, int qty)
+{
+    if(qty != 0)
+        m_IDQtys[id] = qty; //Store/replace the key with the value
+    else
+        m_IDQtys.erase(id); //Erase the the key-value pair
+}

--- a/src/widgets/menulist.hpp
+++ b/src/widgets/menulist.hpp
@@ -1,0 +1,39 @@
+#pragma once
+#include <QListWidget>
+#include "src/widgets/menulistitem.hpp"
+
+using IDQtys = std::map<IDs,Qty>;
+
+class MenuList : public QListWidget
+{
+    Q_OBJECT
+
+public:
+    /* Constructor */
+    MenuList(QWidget* parent);
+
+    /* Getters */
+    IDQtys getIDQty() const;
+    IDs getSelected() const;
+
+    /* List modifiers */
+    void addItem(RestaurantID, const MenuItem&);
+    void addAllItems(const Restaurant&);
+    void removeItem(IDs);
+
+    /* Quantity */
+    void showQty(bool) const;
+    void resetQty();
+
+signals:
+    void currentMenuItemChanged(IDs) const;
+    void showQtyEmitter(bool) const;
+    void resetQtyEmitter() const;
+
+private slots:
+    void currentMenuItemHandler(int row) const;
+    void quantityChangedHandler(IDs, Qty);
+
+private:
+    IDQtys m_IDQtys;
+};

--- a/src/widgets/menulistitem.cpp
+++ b/src/widgets/menulistitem.cpp
@@ -1,0 +1,99 @@
+#include "menulistitem.hpp"
+#include "ui_menulistitem.h"
+
+/* Static variables */
+const QSize MenuListItem::itemSizeHint(200, 80);
+
+/* Constructor */
+MenuListItem::MenuListItem(QWidget* parent, RestaurantID restID, MenuItem menuItem)
+    : QWidget(parent), m_ids(restID, 0), m_ui(new Ui::MenuListItem) //TODO replace 0 with menuItem.GetNumber()
+{
+    m_ui->setupUi(this);
+
+    setStyleSheet("QWidget { color: white; }"
+                  "QSpinBox { color: black; }");
+
+    QFont font("Font Awesome 5 Free");
+
+    /* Icon */
+    font.setPixelSize(30);
+    m_ui->icon->setFont(font);
+    m_ui->icon->setText("\uf805");
+
+    /* Name */
+    m_ui->name->setWordWrap(true);
+    font.setPixelSize(14);
+    m_ui->name->setFont(font);
+    m_ui->name->setText(QString::fromStdString(menuItem.GetName()));
+
+    /* Price */
+    font.setPixelSize(12);
+    m_ui->price->setFont(font);
+    m_ui->price->setText("\uf155 " + QString::number(menuItem.GetPrice(), 'f', 2));
+
+    /* Quantity */
+    font.setPixelSize(12);
+    m_ui->quantity->setFont(font);
+    m_ui->quantity->setText("Qty");
+
+    //Defaults the quantity widgets to hide
+    showQty(false);
+
+    /*
+     * Converts the value change signal of the spin box
+     * into a signal that emits an ID and quantity
+     *
+     * Note:
+     * The old-style connect is being used because QSpinBox::valueChanged()
+     * is overloaded with an int and QString parameter
+     */
+    connect(m_ui->spinBox_qty, SIGNAL(valueChanged(int)), this, SLOT(valueToIDAndValueConverter(int)));
+}
+
+/* Destructor */
+MenuListItem::~MenuListItem()
+{
+    delete m_ui;
+}
+
+/* Getters */
+Qty MenuListItem::getQty() const
+{
+    return m_ui->spinBox_qty->value();
+}
+
+IDs MenuListItem::getIDs() const
+{
+    return m_ids;
+}
+
+QSize MenuListItem::getItemSizeHint()
+{
+    return itemSizeHint;
+}
+
+/* Public slots */
+void MenuListItem::showQty(bool v)
+{
+    if(v)
+    {
+        m_ui->quantity->show();
+        m_ui->spinBox_qty->show();
+    }
+    else
+    {
+        m_ui->quantity->hide();
+        m_ui->spinBox_qty->hide();
+    }
+}
+
+void MenuListItem::resetQty()
+{
+    m_ui->spinBox_qty->setValue(0);
+}
+
+/* Private slots */
+void MenuListItem::valueToIDAndValueConverter(int qty) const
+{
+    emit quantityChanged(m_ids, qty);
+}

--- a/src/widgets/menulistitem.hpp
+++ b/src/widgets/menulistitem.hpp
@@ -1,0 +1,45 @@
+#pragma once
+#include <QWidget>
+#include "src/datastore/Restaurant.hpp"
+
+using Qty = int;
+using MenuID = int;
+using RestaurantID = int;
+using IDs = std::pair<RestaurantID,MenuID>;
+
+namespace Ui
+{
+class MenuListItem;
+}
+
+class MenuListItem : public QWidget
+{
+    Q_OBJECT
+
+public:
+    /* Constructor */
+    MenuListItem(QWidget* parent, RestaurantID, MenuItem);
+
+    /* Destructor */
+    ~MenuListItem();
+
+    /* Getters */
+    Qty getQty() const;
+    IDs getIDs() const;
+    static QSize getItemSizeHint();
+
+public slots:
+    void showQty(bool);
+    void resetQty();
+
+signals:
+    void quantityChanged(IDs, Qty) const;
+
+private slots:
+    void valueToIDAndValueConverter(int) const;
+
+private:
+    IDs m_ids;
+    Ui::MenuListItem* m_ui;
+    static const QSize itemSizeHint;
+};

--- a/src/widgets/menulistitem.ui
+++ b/src/widgets/menulistitem.ui
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>MenuListItem</class>
+ <widget class="QWidget" name="MenuListItem">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>200</width>
+    <height>80</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <widget class="QLabel" name="icon">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>20</y>
+     <width>30</width>
+     <height>30</height>
+    </rect>
+   </property>
+   <property name="text">
+    <string>icon</string>
+   </property>
+  </widget>
+  <widget class="QWidget" name="layoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>49</x>
+     <y>11</y>
+     <width>141</width>
+     <height>61</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QLabel" name="name">
+      <property name="text">
+       <string>name</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLabel" name="price">
+        <property name="text">
+         <string>price</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="spinBox_qty">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="maximum">
+         <number>50</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="quantity">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>quantity</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/windows/mainwindow.cpp
+++ b/src/windows/mainwindow.cpp
@@ -46,7 +46,8 @@ MainWindow::MainWindow()
     //Initial view for dashboard
     changeView(0);
 
-    RestaurantDataStore store;
+    //Load the restaurant database from the file
+    m_store.load(""); //TODO add your database directory here (include '/' at the end)
 
     // WARNING: Put database filepath here
     store.load("");
@@ -54,9 +55,16 @@ MainWindow::MainWindow()
 
     /* Restaurant list */
     m_restaurantList = new RestaurantList(m_ui->restaurantList);
-    m_restaurantList->setDragDropMode(QAbstractItemView::DragDrop);
-    m_restaurantList->setAcceptDrops(true);
-    m_restaurantList->addItems(store.list.begin(), store.list.end());
+    m_restaurantList->addItems(m_store.list.begin(), m_store.list.end());
+
+    /* Menu list */
+    m_menuList = new MenuList(m_ui->menuList);
+    m_menuList->setWrapping(true);
+    m_menuList->setFlow(QListView::LeftToRight);
+
+    //On current restaurant change, display its menu items
+    connect(m_restaurantList, &RestaurantList::currentRestaurantChanged,
+            this, &MainWindow::menuListChange);
 }
 
 /* Destructor */
@@ -149,4 +157,11 @@ void MainWindow::changeNavState(ViewStates state)
         m_navbar->item(9)->setHidden(false);
         break;
     }
+}
+
+void MainWindow::menuListChange(int id)
+{
+    Restaurant restaurant = m_store.FindbyNumber(id);
+    m_ui->currentRestaurantName->setText(QString::fromStdString(restaurant.GetName()));
+    m_menuList->addAllItems(restaurant);
 }

--- a/src/windows/mainwindow.cpp
+++ b/src/windows/mainwindow.cpp
@@ -47,11 +47,7 @@ MainWindow::MainWindow()
     changeView(0);
 
     //Load the restaurant database from the file
-    m_store.load(""); //TODO add your database directory here (include '/' at the end)
-
-    // WARNING: Put database filepath here
-    store.load("");
-
+    m_store.load("D:/Projects/FastFoodFinder/src/datastore/RestaurantData.csv"); //WARNING Put database filepath here
 
     /* Restaurant list */
     m_restaurantList = new RestaurantList(m_ui->restaurantList);

--- a/src/windows/mainwindow.cpp
+++ b/src/windows/mainwindow.cpp
@@ -47,7 +47,7 @@ MainWindow::MainWindow()
     changeView(0);
 
     //Load the restaurant database from the file
-    m_store.load("D:/Projects/FastFoodFinder/src/datastore/RestaurantData.csv"); //WARNING Put database filepath here
+    m_store.load(""); //WARNING Put database filepath here
 
     /* Restaurant list */
     m_restaurantList = new RestaurantList(m_ui->restaurantList);

--- a/src/windows/mainwindow.hpp
+++ b/src/windows/mainwindow.hpp
@@ -2,6 +2,8 @@
 #include <QMainWindow>
 #include "src/widgets/navbar.hpp"
 #include "src/widgets/restaurantlist.hpp"
+#include "src/widgets/menulist.hpp"
+#include "src/datastore/RestaurantDataStore.hpp"
 
 namespace Ui
 {
@@ -28,9 +30,12 @@ signals:
 private slots:
     void changeView(int);
     void changeNavState(ViewStates);
+    void menuListChange(int);
 
 private:
     Ui::MainWindow* m_ui;
     NavBar* m_navbar;
     RestaurantList* m_restaurantList;
+    MenuList* m_menuList;
+    RestaurantDataStore m_store;
 };

--- a/src/windows/mainwindow.ui
+++ b/src/windows/mainwindow.ui
@@ -95,16 +95,87 @@
     </widget>
     <widget class="QWidget" name="viewRestaurantView">
      <property name="styleSheet">
-      <string notr="true">QWidget#viewRestaurantView { background-color: #7DD8FF; }</string>
+      <string notr="true">QWidget#viewRestaurantView { background-color: #7DD8FF; }
+
+QWidget#currentRestaurantName {
+background-color: #303030;
+font-size: 46px;
+color: white;
+font:bold italic;
+}
+
+QWidget#menu {
+color: black;
+background-color: #7F7F7F;
+font-size: 28px;
+font: bold italic;
+}</string>
      </property>
      <widget class="QWidget" name="restaurantList" native="true">
       <property name="geometry">
        <rect>
-        <x>520</x>
+        <x>530</x>
         <y>0</y>
-        <width>191</width>
+        <width>180</width>
         <height>600</height>
        </rect>
+      </property>
+     </widget>
+     <widget class="QWidget" name="menuList" native="true">
+      <property name="geometry">
+       <rect>
+        <x>40</x>
+        <y>169</y>
+        <width>440</width>
+        <height>370</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true"/>
+      </property>
+     </widget>
+     <widget class="QLabel" name="currentRestaurantName">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>530</width>
+        <height>90</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true"/>
+      </property>
+      <property name="text">
+       <string>Restaurant</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
+      </property>
+     </widget>
+     <widget class="QLabel" name="menu">
+      <property name="geometry">
+       <rect>
+        <x>40</x>
+        <y>130</y>
+        <width>440</width>
+        <height>40</height>
+       </rect>
+      </property>
+      <property name="styleSheet">
+       <string notr="true"/>
+      </property>
+      <property name="text">
+       <string>MENU</string>
+      </property>
+      <property name="textFormat">
+       <enum>Qt::PlainText</enum>
+      </property>
+      <property name="scaledContents">
+       <bool>false</bool>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignCenter</set>
       </property>
      </widget>
     </widget>


### PR DESCRIPTION
Closes #6 

### Key features
* Able to list all menu items of a given restaurant
* If needed, the list is able to display a quantity spin box that will record all changes
* When needed, the list is able to return an `std::map` of all the menu IDs and quantity related to it
* `View Restaurants` now displays all menu items when a restaurant is selected

### Future Improvements
* none

### Notes
When `MenuItem` holds a menu item ID (backend future update), make sure to set the `m_id` in `MenuListItem` appropriately.