### PR TITLE
Restaurant list doesn't display deleted items

### DIFF
--- a/FastFoodFinder.pro
+++ b/FastFoodFinder.pro
@@ -34,6 +34,7 @@ HEADERS += \
     src/widgets/restaurantlist.hpp \
     src/datastore/MyDblLinkList.hpp \
     src/datastore/Restaurant.hpp \
+    src/datastore/MenuItem.hpp \
     src/datastore/RestaurantDataStore.hpp \
     src/datastore/Trip.hpp \
     src/datastore/TripDataStore.hpp \
@@ -50,6 +51,7 @@ SOURCES += \
     src/widgets/navitem.cpp \
     src/widgets/restaurantlist.cpp \
     src/datastore/Restaurant.cpp \
+    src/datastore/MenuItem.cpp \
     src/datastore/RestaurantDataStore.cpp \
     src/datastore/Trip.cpp \
     src/datastore/TripDataStore.cpp \

--- a/src/widgets/restaurantlist.cpp
+++ b/src/widgets/restaurantlist.cpp
@@ -70,11 +70,6 @@ void RestaurantList::removeItem(const Restaurant& rest)
     }
 }
 
-void RestaurantList::clearItems()
-{
-    QListWidget::clear();
-}
-
 /* Private slots */
 void RestaurantList::rowToIDConverter(int row) const
 {

--- a/src/widgets/restaurantlist.cpp
+++ b/src/widgets/restaurantlist.cpp
@@ -28,6 +28,9 @@ RestaurantList::RestaurantList(QWidget* parent)
 /* List modifiers */
 void RestaurantList::addItem(const Restaurant& rest)
 {
+    if(rest.IsDeleted())
+        return;
+
     QFont font("Font Awesome 5 Free", 12);
     QString content = "\uf2e7 " + QString::fromStdString(rest.GetName()) + "\n" +
                       "\uf3c5 " + QString::number(rest.GetDistSaddleback(), 'f', 2) + " mi.";

--- a/src/widgets/restaurantlist.cpp
+++ b/src/widgets/restaurantlist.cpp
@@ -25,6 +25,17 @@ RestaurantList::RestaurantList(QWidget* parent)
     connect(this, &QListWidget::currentRowChanged, this, &RestaurantList::rowToIDConverter);
 }
 
+/* Getters */
+ID RestaurantList::getSelected() const
+{
+    QListWidgetItem* item = QListWidget::currentItem();
+
+    if(item != nullptr)
+        return item->data(Qt::ItemDataRole::UserRole).toInt();
+    else
+        return -1;
+}
+
 /* List modifiers */
 void RestaurantList::addItem(const Restaurant& rest)
 {

--- a/src/widgets/restaurantlist.cpp
+++ b/src/widgets/restaurantlist.cpp
@@ -1,7 +1,7 @@
 #include "restaurantlist.hpp"
 
 /* Static variables */
-const QSize RestaurantList::itemSizeHint(190, 70);
+const QSize RestaurantList::itemSizeHint(170, 70);
 
 /* Constructor */
 RestaurantList::RestaurantList(QWidget* parent)

--- a/src/widgets/restaurantlist.cpp
+++ b/src/widgets/restaurantlist.cpp
@@ -26,7 +26,7 @@ RestaurantList::RestaurantList(QWidget* parent)
 }
 
 /* Getters */
-ID RestaurantList::getSelected() const
+RestaurantID RestaurantList::getSelected() const
 {
     QListWidgetItem* item = QListWidget::currentItem();
 

--- a/src/widgets/restaurantlist.hpp
+++ b/src/widgets/restaurantlist.hpp
@@ -2,7 +2,7 @@
 #include <QListWidget>
 #include "src/datastore/Restaurant.hpp"
 
-using ID = int;
+using RestaurantID = int;
 
 class RestaurantList : public QListWidget
 {
@@ -13,7 +13,7 @@ public:
     RestaurantList(QWidget* parent);
 
     /* Getters */
-    ID getSelected() const;
+    RestaurantID getSelected() const;
     template<typename Container>
     void getRestaurantIDs(Container&) const;
 
@@ -26,7 +26,7 @@ public:
     void removeItems(Iterator begin, Iterator end);
 
 signals:
-    void currentRestaurantChanged(ID) const;
+    void currentRestaurantChanged(RestaurantID) const;
 
 private slots:
     void rowToIDConverter(int row) const;

--- a/src/widgets/restaurantlist.hpp
+++ b/src/widgets/restaurantlist.hpp
@@ -27,7 +27,7 @@ public:
     void clearItems();
 
 signals:
-    void currentRestaurantChanged(int ID) const;
+    void currentRestaurantChanged(ID) const;
 
 private slots:
     void rowToIDConverter(int row) const;

--- a/src/widgets/restaurantlist.hpp
+++ b/src/widgets/restaurantlist.hpp
@@ -1,7 +1,8 @@
 #pragma once
-#include <vector>
 #include <QListWidget>
 #include "src/datastore/Restaurant.hpp"
+
+using ID = int;
 
 class RestaurantList : public QListWidget
 {
@@ -11,8 +12,8 @@ public:
     /* Constructor */
     RestaurantList(QWidget* parent);
 
-    /* Static getters */
-    static QSize getItemSizeHint();
+    /* Getters */
+    ID getSelected() const;
     template<typename Container>
     void getRestaurantIDs(Container&) const;
 

--- a/src/widgets/restaurantlist.hpp
+++ b/src/widgets/restaurantlist.hpp
@@ -24,7 +24,6 @@ public:
     void removeItem(const Restaurant&);
     template<typename Iterator>
     void removeItems(Iterator begin, Iterator end);
-    void clearItems();
 
 signals:
     void currentRestaurantChanged(ID) const;

--- a/src/windows/mainwindow.cpp
+++ b/src/windows/mainwindow.cpp
@@ -49,6 +49,7 @@ MainWindow::MainWindow()
     changeView(0);
 
     RestaurantDataStore store;
+    store.load(""); //TODO add your database directory here (include '/' at the end)
 
     /* Restaurant list */
     m_restaurantList = new RestaurantList(m_ui->restaurantList);


### PR DESCRIPTION
### Key features
* Adds `MenuItem` class to the `.pro` file (last update to the backend classes forgot this)
* If the restaurant item is *deleted*, it doesn't display it in the restaurant list
* Adds a *getter* for the current selected restaurant
* Smaller restaurant item size hint to remove horizontal scroll bar

### Future Improvements
* none

### Notes
none