### PR TITLE
Menu list quantity feature additions

### DIFF
--- a/src/widgets/menulist.cpp
+++ b/src/widgets/menulist.cpp
@@ -2,7 +2,7 @@
 
 /* Constructor */
 MenuList::MenuList(QWidget* parent)
-    : QListWidget(parent)
+    : QListWidget(parent), m_showQty(false)
 {
     /* List widget settings */
     QListWidget::setStyleSheet("QListWidget { background-color: #303030; color: white; }");
@@ -51,6 +51,8 @@ void MenuList::addItem(RestaurantID restID, const MenuItem& menuItem)
     MenuListItem* widget = new MenuListItem(this, restID, menuItem);
     QListWidget::setItemWidget(listItem, widget);
 
+    widget->showQty(m_showQty);
+
     //Allows all MenuItem's to toggle its quantity widgets through the emitter
     connect(this, &MenuList::showQtyEmitter, widget, &MenuListItem::showQty);
 
@@ -85,8 +87,9 @@ void MenuList::removeItem(IDs id)
 }
 
 /* Quantity */
-void MenuList::showQty(bool v) const
+void MenuList::showQty(bool v)
 {
+    m_showQty = v;
     emit showQtyEmitter(v);
 }
 

--- a/src/widgets/menulist.cpp
+++ b/src/widgets/menulist.cpp
@@ -39,6 +39,22 @@ IDs MenuList::getSelected() const
         return IDs(-1, -1);
 }
 
+/* Setters */
+void MenuList::setQty(IDs id, int qty) const
+{
+    for(int i = 0; i < QListWidget::count(); i++)
+    {
+        QListWidgetItem* listItem = QListWidget::item(i);
+        MenuListItem* widget = dynamic_cast<MenuListItem*>(QListWidget::itemWidget(listItem));
+
+        if(widget != nullptr && id == widget->getIDs())
+        {
+            widget->setQty(qty);
+            return;
+        }
+    }
+}
+
 /* List modifiers */
 void MenuList::addItem(RestaurantID restID, const MenuItem& menuItem)
 {

--- a/src/widgets/menulist.hpp
+++ b/src/widgets/menulist.hpp
@@ -22,7 +22,7 @@ public:
     void removeItem(IDs);
 
     /* Quantity */
-    void showQty(bool) const;
+    void showQty(bool);
     void resetQty();
 
 signals:
@@ -36,4 +36,5 @@ private slots:
 
 private:
     IDQtys m_IDQtys;
+    bool m_showQty;
 };

--- a/src/widgets/menulist.hpp
+++ b/src/widgets/menulist.hpp
@@ -16,6 +16,9 @@ public:
     IDQtys getIDQty() const;
     IDs getSelected() const;
 
+    /* Setters */
+    void setQty(IDs, int qty) const;
+
     /* List modifiers */
     void addItem(RestaurantID, const MenuItem&);
     void addAllItems(const Restaurant&);

--- a/src/widgets/menulistitem.cpp
+++ b/src/widgets/menulistitem.cpp
@@ -72,6 +72,12 @@ QSize MenuListItem::getItemSizeHint()
     return itemSizeHint;
 }
 
+/* Setters */
+void MenuListItem::setQty(int v)
+{
+    m_ui->spinBox_qty->setValue(v);
+}
+
 /* Public slots */
 void MenuListItem::showQty(bool v)
 {

--- a/src/widgets/menulistitem.hpp
+++ b/src/widgets/menulistitem.hpp
@@ -28,6 +28,9 @@ public:
     IDs getIDs() const;
     static QSize getItemSizeHint();
 
+    /* Setters */
+    void setQty(int);
+
 public slots:
     void showQty(bool);
     void resetQty();


### PR DESCRIPTION
### Key features
* `MenuList::showQty()` can now be called before adding items and will show the spinbox
* Added a way to set the quantity of an item in the list

### Future Improvements
* none

### Notes
none
